### PR TITLE
Explain how to find log4j and note limitations

### DIFF
--- a/scanning/README.md
+++ b/scanning/README.md
@@ -52,17 +52,16 @@ Checks if the application or system is using Log4j2.
 | DIVD | This scanner will recursively scan paths including archives for vulnerable log4j versions and JndiLookup.class files. |https://github.com/dtact/divd-2021-00038--log4j-scanner |
 | Forescout | Samples of exploit attempts; The evolving Log4Shell story: analysis of ongoing and future exploits | https://github.com/Forescout/log4j_response |
 | GoHoyer[^2] | Bash script to detect vulnerable log4j-2 jar files | https://gist.github.com/gohoyer/9a40d8e0e46c4c78c99cc9d5e9adc5aa |
-| JFrog[^3] | Detects files containing vulnerable Log4j versions and also scans for locations in code where log4j 2 is called. | https://github.com/jfrog/log4j-tools |
-| Kelvin Tegelaar[^4] | Open sourced(MIT license) PowerShell log4j detection. Uses "Everything" to prevent high system load | https://www.cyberdrain.com/monitoring-with-powershell-detecting-log4j-files/ |
+| JFrog | Detects files containing vulnerable Log4j versions and also scans for locations in code where log4j 2 is called. | https://github.com/jfrog/log4j-tools |
+| Kelvin Tegelaar[^3] | Open sourced(MIT license) PowerShell log4j detection. Uses "Everything" to prevent high system load | https://www.cyberdrain.com/monitoring-with-powershell-detecting-log4j-files/ |
 | Mergebase | Detects vulnerable Log4J versions on your file-system. It is able to find instances that are hidden several layers deep. Linux/Windows/Mac | https://github.com/mergebase/log4j-detector |
 | NCCgroup  | Version hashes (MD5, SHA1 and SHA256) for log4j2 versions| https://github.com/nccgroup/Cyber-Defence/tree/master/Intelligence/CVE-2021-44228 |
-| Neo23x0[^5]   | Florian Roth Log4j2 detection script | https://gist.github.com/Neo23x0/e4c8b03ff8cdf1fa63b7d15db6e3860b |
-| sp4ir[^6]     | Powershell script to detect Log4Shell| https://github.com/sp4ir/incidentresponse/blob/35a2faae8512884bcd753f0de3fa1adc6ec326ed/Get-Log4shellVuln.ps1 |
+| Neo23x0[^4]   | Florian Roth Log4j2 detection script | https://gist.github.com/Neo23x0/e4c8b03ff8cdf1fa63b7d15db6e3860b |
+| sp4ir[^5]     | Powershell script to detect Log4Shell| https://github.com/sp4ir/incidentresponse/blob/35a2faae8512884bcd753f0de3fa1adc6ec326ed/Get-Log4shellVuln.ps1 |
 | Syft | Open source SBOM scanner, can detect all dependencies including log4j | https://github.com/anchore/syft/ |
 
 [^1]: Only scans filenames, does not search for vulnerable JndiLookup.class, does not scan nested Java archives, does not scan .war and .ear files.
 [^2]: Only scans filenames, does not scan nested Java archives, does not scan .war and .ear files.
-[^3]: Does not scan nested war files, does not scan .ear files.
-[^4]: Does not scan nested Java archives, does not scan .war and .ear files.
-[^5]: Windows and Linux scripts are limited and do not scan nested java archives.
-[^6]: Only scans filenames, does not scan nested Java archives, does not scan .war and .ear files.
+[^3]: Does not scan nested Java archives, does not scan .war and .ear files.
+[^4]: Windows and Linux scripts are limited and do not scan nested java archives.
+[^5]: Only scans filenames, does not scan nested Java archives, does not scan .war and .ear files.

--- a/scanning/README.md
+++ b/scanning/README.md
@@ -56,12 +56,13 @@ Checks if the application or system is using Log4j2.
 | Kelvin Tegelaar[^4] | Open sourced(MIT license) PowerShell log4j detection. Uses "Everything" to prevent high system load | https://www.cyberdrain.com/monitoring-with-powershell-detecting-log4j-files/ |
 | Mergebase | Detects vulnerable Log4J versions on your file-system. It is able to find instances that are hidden several layers deep. Linux/Windows/Mac | https://github.com/mergebase/log4j-detector |
 | NCCgroup  | Version hashes (MD5, SHA1 and SHA256) for log4j2 versions| https://github.com/nccgroup/Cyber-Defence/tree/master/Intelligence/CVE-2021-44228 |
-| Neo23x0   | Florian Roth Log4j2 detection script | https://gist.github.com/Neo23x0/e4c8b03ff8cdf1fa63b7d15db6e3860b |
-| sp4ir[^5]     | Powershell script to detect Log4Shell| https://github.com/sp4ir/incidentresponse/blob/35a2faae8512884bcd753f0de3fa1adc6ec326ed/Get-Log4shellVuln.ps1 |
+| Neo23x0[^5]   | Florian Roth Log4j2 detection script | https://gist.github.com/Neo23x0/e4c8b03ff8cdf1fa63b7d15db6e3860b |
+| sp4ir[^6]     | Powershell script to detect Log4Shell| https://github.com/sp4ir/incidentresponse/blob/35a2faae8512884bcd753f0de3fa1adc6ec326ed/Get-Log4shellVuln.ps1 |
 | Syft | Open source SBOM scanner, can detect all dependencies including log4j | https://github.com/anchore/syft/ |
 
 [^1]: Only scans filenames, does not search for vulnerable JndiLookup.class, does not scan nested Java archives, does not scan .war and .ear files.
 [^2]: Only scans filenames, does not scan nested Java archives, does not scan .war and .ear files.
 [^3]: Does not scan nested war files, does not scan .ear files.
 [^4]: Does not scan nested Java archives, does not scan .war and .ear files.
-[^5]: Only scans filenames, does not scan nested Java archives, does not scan .war and .ear files.
+[^5]: Windows and Linux scripts are limited and do not scan nested java archives.
+[^6]: Only scans filenames, does not scan nested Java archives, does not scan .war and .ear files.

--- a/scanning/README.md
+++ b/scanning/README.md
@@ -30,18 +30,38 @@ Checks if the application is vulnerable to CVE-2021-44228.
 
 
 ## Log4j2 Detection
+
+### How to find
+- Java applications are distributed in Java ARchives, also known as JAR files. JAR files contain, among other things, compiled Java code in .class files.
+- The file that contains the Log4shell vulnerability (CVE-2021-44228) is: `JndiLookup.class` which is part of the `log4j-core` library.
+- There are three commonly used extensions for Java Archives: jar, war and ear. Each Java archive may contain nested archives. 
+  For example:
+  - `ear` files often contain jar and war files
+  - `war` files often contain jar files
+  - `jar` files may contain other jar files
+- In order to find the vulnerable 'JndiLookup.class' file and by extension the log4j-core library, each found Java archive must be recursively scanned; meaning that nested Java archives must also be scanned.
+
+
+### Links
 Checks if the application or system is using Log4j2.
 | Source      | Notes        | Links |
 |:----------------|:----------------|:---------------:|
 | 1lann  | Scans a file or folder recursively for jar files that may be vulnerable | https://github.com/1lann/log4shelldetect |
 | Aholzel | Splunk query's to detect the used Log4j version and detect abuse | https://github.com/aholzel/log4j_splunk_querys |
-| Devotech | Powershell: Queries domain servers and scans for log4j-core files. (slow) | https://github.com/devotech/check-log4j |
+| Devotech[^1] | Powershell: Queries domain servers and scans for log4j-core files. (slow) | https://github.com/devotech/check-log4j |
 | DIVD | This scanner will recursively scan paths including archives for vulnerable log4j versions and JndiLookup.class files. |https://github.com/dtact/divd-2021-00038--log4j-scanner |
 | Forescout | Samples of exploit attempts; The evolving Log4Shell story: analysis of ongoing and future exploits | https://github.com/Forescout/log4j_response |
-| GoHoyer | Bash script to detect vulnerable log4j-2 jar files | https://gist.github.com/gohoyer/9a40d8e0e46c4c78c99cc9d5e9adc5aa |
-| Kelvin Tegelaar | Open sourced(MIT license) PowerShell log4j detection. Uses "Everything" to prevent high system load | https://www.cyberdrain.com/monitoring-with-powershell-detecting-log4j-files/ |
+| GoHoyer[^2] | Bash script to detect vulnerable log4j-2 jar files | https://gist.github.com/gohoyer/9a40d8e0e46c4c78c99cc9d5e9adc5aa |
+| JFrog[^3] | Detects files containing vulnerable Log4j versions and also scans for locations in code where log4j 2 is called. | https://github.com/jfrog/log4j-tools |
+| Kelvin Tegelaar[^4] | Open sourced(MIT license) PowerShell log4j detection. Uses "Everything" to prevent high system load | https://www.cyberdrain.com/monitoring-with-powershell-detecting-log4j-files/ |
 | Mergebase | Detects vulnerable Log4J versions on your file-system. It is able to find instances that are hidden several layers deep. Linux/Windows/Mac | https://github.com/mergebase/log4j-detector |
 | NCCgroup  | Version hashes (MD5, SHA1 and SHA256) for log4j2 versions| https://github.com/nccgroup/Cyber-Defence/tree/master/Intelligence/CVE-2021-44228 |
 | Neo23x0   | Florian Roth Log4j2 detection script | https://gist.github.com/Neo23x0/e4c8b03ff8cdf1fa63b7d15db6e3860b |
-| sp4ir     | Powershell script to detect Log4Shell| https://github.com/sp4ir/incidentresponse/blob/35a2faae8512884bcd753f0de3fa1adc6ec326ed/Get-Log4shellVuln.ps1 |
+| sp4ir[^5]     | Powershell script to detect Log4Shell| https://github.com/sp4ir/incidentresponse/blob/35a2faae8512884bcd753f0de3fa1adc6ec326ed/Get-Log4shellVuln.ps1 |
 | Syft | Open source SBOM scanner, can detect all dependencies including log4j | https://github.com/anchore/syft/ |
+
+[^1]: Only scans filenames, does not search for vulnerable JndiLookup.class, does not scan nested Java archives, does not scan .war and .ear files.
+[^2]: Only scans filenames, does not scan nested Java archives, does not scan .war and .ear files.
+[^3]: Does not scan nested war files, does not scan .ear files.
+[^4]: Does not scan nested Java archives, does not scan .war and .ear files.
+[^5]: Only scans filenames, does not scan nested Java archives, does not scan .war and .ear files.

--- a/software/README.md
+++ b/software/README.md
@@ -290,7 +290,7 @@ The `Version` relates to the `Status` column. If `Status` field is set to 'Vulne
 | Bitdefender   | GravityZone On-Premises | Unknown | Not vuln | Not vuln | Not vuln | Not vuln | |[source](https://businessinsights.bitdefender.com/security-advisory-bitdefender-response-to-critical-0-day-apache-log4j2-vulnerability) |
 | Bitnami       | Unknown | Unknown | Not vuln | Fix |  | | |[source](https://docs.bitnami.com/general/security/security-2021-12-10/) |
 | Bitwarden     | Bitwarden | All |  | Not vuln |  | | | [source](https://community.bitwarden.com/t/log4j-log4shell-cve-is-bitwarden-affected-due-to-docker-image/36177) |
-| BioJava       | Java library for processing biological data | 6.0.3 | Not vuln | Fix |  | | |[source](https://github.com/biojava/biojava/releases/tag/biojava-6.0.3) |
+| BioJava       | Java library for processing biological data | 6.0.3 | Not vuln | Fix | Fix |  Vulnerable |  |[source](https://github.com/biojava/biojava/releases/tag/biojava-6.0.3) |
 | BlackBerry    | Enterprise Mobility Server | 2.12 and above | Not vuln | Workaround |  | | |[source](https://support.blackberry.com/community/s/article/90708) |
 | BlackBerry    | Workspaces On-prem Server | All | Not vuln | Workaround |  | | |[source](https://support.blackberry.com/community/s/article/90708) |
 | BlackBerry    |  2FA | All | Not vuln | Workaround |  | | |[source](https://support.blackberry.com/community/s/article/90708) |


### PR DESCRIPTION
- Added explanation of how to find log4j in java archives.
  This does not seem to be common knowledge and is essential in finding vulnerable software.
- Noted limitations of some of the linked tools. The other tools do not have these limitations.

